### PR TITLE
Result processing

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,9 +112,8 @@ def get_from_seed():
     try:
         group_seed = int(request.json['seed'])
     except ValueError:
-        # Return an error when error handling implemented
-        # return { "error": "You need to input a number for the seed" }
-        return { "mmo_spawns": [] }
+        return { "error": "You need to input a number for the seed" }
+    
     results = pla.check_from_seed(group_seed,
                                   request.json['rolls'],
                                   request.json['frencounter'],
@@ -129,9 +128,8 @@ def get_alpha_from_seed():
     try:
         group_seed = int(request.json['seed'])
     except ValueError:
-        # Return an error when error handling implemented
-        # return { "error": "You need to input a number for the seed" }
-        return { "alpha_spawns": [] }
+        return { "error": "You need to input a number for the seed" }
+    
     results = pla.check_alpha_from_seed(group_seed,
                                         request.json['rolls'],
                                         request.json['isalpha'],
@@ -154,9 +152,8 @@ def check_multiseed():
     try:
         group_seed = int(request.json['seed'])
     except ValueError:
-        # Return an error when error handling implemented
-        # return { "error": "You need to input a number for the seed" }
-        return { "multi_spawns": {} }
+        return { "error": "You need to input a number for the seed" }
+
     results = pla.check_multi_spawner_seed(group_seed,
                                            request.json['rolls'],
                                            request.json['group_id'],

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from nxreader import NXReader
 import pla
 from pla.data import hisuidex
 from pla.saves import read_research, rolls_from_research
-from pla.data.data_utils import flatten_all_map_mmo_results, flatten_map_mmo_results, flatten_normal_outbreaks
+from pla.data.data_utils import flatten_all_map_mmo_results, flatten_map_mmo_results, flatten_normal_outbreaks, flatten_multi
 
 mimetypes.add_type('application/javascript', '.js')
 mimetypes.add_type('application/javascript', '.mjs')
@@ -63,54 +63,51 @@ def settings():
 
 
 # API ROUTES
-@app.route('/read-mmos', methods=['POST'])
+@app.route('/api/read-mmos', methods=['POST'])
 def read_mmos():
-    #results = pla.get_all_map_mmos(reader, request.json['rolls'], request.json['inmap'])
     results = pla.get_all_map_mmos(reader, request.json['rolls'], False)
-    return { "mmo_spawns": flatten_all_map_mmo_results(results, config.get('FILTER_ON_SERVER', False)) }
+    return { "results": flatten_all_map_mmo_results(results, config.get('FILTER_ON_SERVER', False)) }
 
-@app.route('/read-one-map', methods=['POST'])
+@app.route('/api/read-one-map', methods=['POST'])
 def read_one_map():
-    #results = pla.get_map_mmos(reader,request.json['mapname'],request.json['rolls'], request.json['inmap'])
     results = pla.get_map_mmos(reader,request.json['mapname'],request.json['rolls'], False)
-    return { "mmo_spawn": flatten_map_mmo_results(results, config.get('FILTER_ON_SERVER', False)) }
+    return { "results": flatten_map_mmo_results(results, config.get('FILTER_ON_SERVER', False)) }
 
-@app.route('/read-normals', methods=['POST'])
+@app.route('/api/read-normals', methods=['POST'])
 def read_normals():
-    #results = pla.read_normal_outbreaks(reader,request.json['rolls'],request.json['inmap'])
     results = pla.read_normal_outbreaks(reader,request.json['rolls'],False)
-    return { "normal_spawns": flatten_normal_outbreaks(results, config.get('FILTER_ON_SERVER', False)) }
+    return { "results": flatten_normal_outbreaks(results, config.get('FILTER_ON_SERVER', False)) }
 
-@app.route('/read-maps', methods=['GET'])
+@app.route('/api/read-maps', methods=['GET'])
 def read_maps():
-    results = pla.get_all_map_names(reader)
+    map_names = pla.get_all_map_names(reader)
     outbreaks = pla.get_all_outbreak_names(reader,False)
-    return { "maps": results, "outbreaks": outbreaks }
+    return { "maps": map_names, "outbreaks": outbreaks }
 
-@app.route('/teleport-to-spawn', methods=['POST'])
+@app.route('/api/teleport-to-spawn', methods=['POST'])
 def teleport():
     pla.teleport_to_spawn(reader,request.json['coords'])
     return ""
 
-@app.route('/read-distortions', methods=['POST'])
+@app.route('/api/read-distortions', methods=['POST'])
 def read_distortions():
     results = pla.check_all_distortions(reader,
                                         request.json['map_name'],
                                         request.json['rolls'])
-    return { "distortion_spawns": results }
+    return { "results": results }
 
-@app.route('/create-distortion', methods=['POST'])
+@app.route('/api/create-distortion', methods=['POST'])
 def create_distortion():
     pla.create_distortion(reader)
     return "Distortion Created"
 
-@app.route('/map-info', methods=['POST'])
+@app.route('/api/map-info', methods=['POST'])
 def get_map_info():
     locations = pla.get_distortion_locations(request.json['map_name'])
     spawns = pla.get_distortion_spawns(request.json['map_name'])
     return { "locations": locations, "spawns": spawns }
 
-@app.route('/check-mmoseed', methods=['POST'])
+@app.route('/api/check-mmoseed', methods=['POST'])
 def get_from_seed():
     try:
         group_seed = int(request.json['seed'])
@@ -125,9 +122,9 @@ def get_from_seed():
                                   request.json['isbonus'],
                                   request.json['frspawns'],
                                   request.json['brspawns'])
-    return { "mmo_spawns": flatten_map_mmo_results(results, config.get('FILTER_ON_SERVER', False)) }
+    return { "results": flatten_map_mmo_results(results, config.get('FILTER_ON_SERVER', False)) }
 
-@app.route('/check-alphaseed', methods=['POST'])
+@app.route('/api/check-alphaseed', methods=['POST'])
 def get_alpha_from_seed():
     try:
         group_seed = int(request.json['seed'])
@@ -140,9 +137,9 @@ def get_alpha_from_seed():
                                         request.json['isalpha'],
                                         request.json['setgender'],
                                         request.json['filter'])
-    return { "alpha_spawns": results }
+    return { "results": [results] }
 
-@app.route('/check-multi-spawn', methods=['POST'])
+@app.route('/api/check-multi-spawn', methods=['POST'])
 def check_multispawner():
     results = pla.check_multi_spawner(reader,
                                       request.json['rolls'],
@@ -150,9 +147,9 @@ def check_multispawner():
                                       request.json['maxalive'],
                                       request.json['maxdepth'],
                                       request.json['isnight'])
-    return { "multi_spawns": results }
+    return { "results": flatten_multi(results, False) }
 
-@app.route('/check-multi-seed', methods=['POST'])
+@app.route('/api/check-multi-seed', methods=['POST'])
 def check_multiseed():
     try:
         group_seed = int(request.json['seed'])
@@ -166,7 +163,7 @@ def check_multiseed():
                                            request.json['maxalive'],
                                            request.json['maxdepth'],
                                            request.json['isnight'])
-    return { "multi_spawns": results}
+    return { "results": flatten_multi(results, False) }
 
 @app.route('/api/hisuidex')
 def pokemon():
@@ -199,6 +196,114 @@ def read_savefile():
             }
     
     return { 'error': 'There was a problem reading your save' }
+
+# existing version of api calls, preserved in case used by external applications
+@app.route('/read-mmos', methods=['POST'])
+def read_mmos_old():
+    #results = pla.get_all_map_mmos(reader, request.json['rolls'], request.json['inmap'])
+    results = pla.get_all_map_mmos(reader, request.json['rolls'], False)
+    return { "mmo_spawns": flatten_all_map_mmo_results(results, config.get('FILTER_ON_SERVER', False)) }
+
+@app.route('/read-one-map', methods=['POST'])
+def read_one_map_old():
+    #results = pla.get_map_mmos(reader,request.json['mapname'],request.json['rolls'], request.json['inmap'])
+    results = pla.get_map_mmos(reader,request.json['mapname'],request.json['rolls'], False)
+    return { "mmo_spawn": flatten_map_mmo_results(results, config.get('FILTER_ON_SERVER', False)) }
+
+@app.route('/read-normals', methods=['POST'])
+def read_normals_old():
+    #results = pla.read_normal_outbreaks(reader,request.json['rolls'],request.json['inmap'])
+    results = pla.read_normal_outbreaks(reader,request.json['rolls'],False)
+    return { "normal_spawns": flatten_normal_outbreaks(results, config.get('FILTER_ON_SERVER', False)) }
+
+@app.route('/read-maps', methods=['GET'])
+def read_maps_old():
+    results = pla.get_all_map_names(reader)
+    outbreaks = pla.get_all_outbreak_names(reader,False)
+    return { "maps": results, "outbreaks": outbreaks }
+
+@app.route('/teleport-to-spawn', methods=['POST'])
+def teleport_old():
+    pla.teleport_to_spawn(reader,request.json['coords'])
+    return ""
+
+@app.route('/read-distortions', methods=['POST'])
+def read_distortions_old():
+    results = pla.check_all_distortions(reader,
+                                        request.json['map_name'],
+                                        request.json['rolls'])
+    return { "distortion_spawns": results }
+
+@app.route('/create-distortion', methods=['POST'])
+def create_distortion_old():
+    pla.create_distortion(reader)
+    return "Distortion Created"
+
+@app.route('/map-info', methods=['POST'])
+def get_map_info_old():
+    locations = pla.get_distortion_locations(request.json['map_name'])
+    spawns = pla.get_distortion_spawns(request.json['map_name'])
+    return { "locations": locations, "spawns": spawns }
+
+@app.route('/check-mmoseed', methods=['POST'])
+def get_from_seed_old():
+    try:
+        group_seed = int(request.json['seed'])
+    except ValueError:
+        # Return an error when error handling implemented
+        # return { "error": "You need to input a number for the seed" }
+        return { "mmo_spawns": [] }
+    results = pla.check_from_seed(group_seed,
+                                  request.json['rolls'],
+                                  request.json['frencounter'],
+                                  request.json['brencounter'],
+                                  request.json['isbonus'],
+                                  request.json['frspawns'],
+                                  request.json['brspawns'])
+    return { "mmo_spawns": flatten_map_mmo_results(results, config.get('FILTER_ON_SERVER', False)) }
+
+@app.route('/check-alphaseed', methods=['POST'])
+def get_alpha_from_seed_old():
+    try:
+        group_seed = int(request.json['seed'])
+    except ValueError:
+        # Return an error when error handling implemented
+        # return { "error": "You need to input a number for the seed" }
+        return { "alpha_spawns": [] }
+    results = pla.check_alpha_from_seed(group_seed,
+                                        request.json['rolls'],
+                                        request.json['isalpha'],
+                                        request.json['setgender'],
+                                        request.json['filter'])
+    return { "alpha_spawns": results }
+
+@app.route('/check-multi-spawn', methods=['POST'])
+def check_multispawner_old():
+    results = pla.check_multi_spawner(reader,
+                                      request.json['rolls'],
+                                      request.json['group_id'],
+                                      request.json['maxalive'],
+                                      request.json['maxdepth'],
+                                      request.json['isnight'])
+    return { "multi_spawns": results }
+
+@app.route('/check-multi-seed', methods=['POST'])
+def check_multiseed_old():
+    try:
+        group_seed = int(request.json['seed'])
+    except ValueError:
+        # Return an error when error handling implemented
+        # return { "error": "You need to input a number for the seed" }
+        return { "multi_spawns": {} }
+    results = pla.check_multi_spawner_seed(group_seed,
+                                           request.json['rolls'],
+                                           request.json['group_id'],
+                                           request.json['maxalive'],
+                                           request.json['maxdepth'],
+                                           request.json['isnight'])
+    return { "multi_spawns": results}
+
+
 
 if __name__ == '__main__':
     app.run(host="localhost", port=8100, debug=True)

--- a/pla/checkalpha.py
+++ b/pla/checkalpha.py
@@ -78,7 +78,6 @@ def check_alpha_from_seed(group_seed,rolls,isalpha,set_gender,pfilter):
 
     if adv <= 50000:
         results = {
-            "spawn": True,
             "rolls": rolls,
             "adv": adv,
             "ivs": ivs,
@@ -89,7 +88,6 @@ def check_alpha_from_seed(group_seed,rolls,isalpha,set_gender,pfilter):
             }
     else:
         results = {
-            "spawn": True,
             "rolls": rolls,
             "adv": adv,
             "ivs": [0,0,0,0,0,0],

--- a/pla/checkdistortion.py
+++ b/pla/checkdistortion.py
@@ -75,7 +75,6 @@ def check_distortion(reader, map_name, distortion_index, rolls):
     if group_seed != 0 and check_not_common_spawn(distortion_index, distortion_name):
             return  {
                 "index": distortion_index,
-                "spawn": True,
                 "generator_seed": generator_seed,
                 "distortion_name": distortion_name,
                 "encounter_slot": encounter_slot,

--- a/pla/checkmmo.py
+++ b/pla/checkmmo.py
@@ -258,6 +258,7 @@ def generate_mass_outbreak_aggressive_path_normal(group_seed,rolls,steps,uniques
                 "ability":ability,
                 "nature":NATURES[nature],
                 "gender":gender,
+                "rolls":rolls,
                 "defaultroute": True
             }
             #print(info)
@@ -287,7 +288,8 @@ def generate_mass_outbreak_aggressive_path_normal(group_seed,rolls,steps,uniques
                     "ivs":ivs,
                     "ability":ability,
                     "nature":NATURES[nature],
-                    "gender":gender
+                    "gender":gender,
+                    "rolls":rolls
                 }
                 paths.append(f"{'|'.join(str(s) for s in steps[:step_i] + [pokemon])}")
                 if len(steps[:step_i]) == sum(steps[:step_i]) and pokemon == 1:

--- a/pla/checkmmo.py
+++ b/pla/checkmmo.py
@@ -57,7 +57,6 @@ def generate_mass_outbreak_aggressive_path(group_seed,rolls,paths,spawns,true_sp
                 info = {
                     "index":f"<span class='pla-results-init'>Initial Spawn " \
                     f"{init_spawn} </span></span>",
-                    "spawn":True,
                     "generator_seed":f"{generator_seed:X}",
                     "species":species,
                     "shiny":shiny,
@@ -103,7 +102,6 @@ def generate_mass_outbreak_aggressive_path(group_seed,rolls,paths,spawns,true_sp
                     info = {
                         #"index":f"Path: {'|'.join(str(s) for s in steps[:step_i] + [pokemon])} </span>",
                         "index": get_index_string(steps[:step_i], pokemon),
-                        "spawn":True,
                         "generator_seed":f"{generator_seed:X}",
                         "species":species,
                         "shiny":shiny,
@@ -175,12 +173,9 @@ def get_bonus_seed(group_seed, path):
             respawn_rng.next()
             respawn_rng.next()
         respawn_rng = XOROSHIRO(respawn_rng.next())
-    bonus_seed = (respawn_rng.next() - 0x82A2B175229D6A5B) & 0xFFFFFFFFFFFFFFFF
-    return bonus_seed
+    return (respawn_rng.next() - 0x82A2B175229D6A5B) & 0xFFFFFFFFFFFFFFFF
 
 def read_mass_outbreak_rng(reader,group_id,rolls,mapcount,chained,species,group_seed,max_spawns,bonus_flag):
-    if species == 201:
-        rolls = 19
     print(f"Species Group: {SPECIES[species]}")
     encounters,encsum = get_encounter_table(reader,group_id,mapcount,bonus_flag)
     paths = nonbonuspaths[str(max_spawns)]
@@ -253,7 +248,6 @@ def generate_mass_outbreak_aggressive_path_normal(group_seed,rolls,steps,uniques
             uniques.add(fixed_seed)
             info = {
                 "index":f"Initial Spawn {init_spawn}</span>",
-                "spawn":True,
                 "generator_seed":f"{generator_seed:X}",
                 "shiny":shiny,
                 "square": square,
@@ -284,7 +278,6 @@ def generate_mass_outbreak_aggressive_path_normal(group_seed,rolls,steps,uniques
                 uniques.add(fixed_seed)
                 info = {
                     "index":f"Path: {'|'.join(str(s) for s in steps[:step_i] + [pokemon])}</span>",
-                    "spawn":True,
                     "generator_seed":f"{generator_seed:X}",
                     "shiny":shiny,
                     "square": square,
@@ -351,35 +344,6 @@ def aggressive_outbreak_pathfind_normal(group_seed,
         if _steps == get_final_normal(spawns):
             return storage,paths
     return None
-
-def next_filtered_aggressive_outbreak_pathfind_normal(group_seed,rolls,spawns):
-    """Check the next outbreak advances until an aggressive path to a pokemon that
-       passes poke_filter exists"""
-    main_rng = XOROSHIRO(group_seed)
-    result = []
-    advance = -1
-
-    while len(result) == 0 and advance < 1:
-        if advance != -1:
-            for _ in range(4*2):
-                main_rng.next()
-            group_seed = main_rng.next()
-            main_rng.reseed(group_seed)
-        advance += 1
-        result,paths = aggressive_outbreak_pathfind_normal(group_seed, rolls, spawns)
-        if result is None:
-            result = []
-    if advance == 0:
-        info = result
-    else:
-        info = {
-            "spawn":False,
-            "description":"Spawner not active"
-            }
-    if advance != 0:
-        return info,paths
-    else:
-        return info,paths
 
 def get_group_seed(reader,group_id,mapcount):
     return reader.read_pointer_int(f"[[[[[[main+42BA6B0]+2B0]+58]+18]+" \
@@ -645,7 +609,7 @@ def read_normal_outbreaks(reader,rolls,inmap):
     for i in range(MAX_MAPS):
         species,group_seed,max_spawns,coordinates = get_normal_outbreak_info(reader,i,inmap)
         if species != 0:
-            display,_ = next_filtered_aggressive_outbreak_pathfind_normal(group_seed,rolls,max_spawns)
+            display,_ = aggressive_outbreak_pathfind_normal(group_seed, rolls, max_spawns)
             
             if display is None:
                 display = []

--- a/pla/checkmulti.py
+++ b/pla/checkmulti.py
@@ -79,7 +79,6 @@ def generate_spawns(group_seed,rolls,group_id,info,path,adv):
             generate_from_seed(fixed_seed,rolls,guaranteed_ivs,set_gender)
         currpath = f"{path[:len(path)-1] + [i+1]}"
         poke = {
-            "spawn":True,
             "ec":f"{ec:X}",
             "pid":f"{pid:X}",
             "ivs":ivs,
@@ -115,7 +114,6 @@ def generate_initial_spawns(group_seed,rolls,group_id,maxalive,info):
         ec,pid,ivs,ability,gender,nature,shiny,square = \
             generate_from_seed(fixed_seed,rolls,guaranteed_ivs,set_gender)
         poke = {
-            "spawn":True,
             "ec":f"{ec:X}",
             "pid":f"{pid:X}",
             "ivs":ivs,

--- a/pla/checkmulti.py
+++ b/pla/checkmulti.py
@@ -9,22 +9,6 @@ encounter_table = json.load(open(RESOURCE_PATH + "/resources/multi-es.json"))
 
 SPAWNER_PTR = "[[main+42a6ee0]+330]"
 
-# Note - this function has undefinied variables - is it in use?
-def read_mass_outbreak_rng(group_seed,rolls,remain):
-    main_rng = XOROSHIRO(group_seed)
-    for respawn in range(0,remain):
-        generator_seed = respawn_rng.next()
-        respawn_rng.next() # spawner 1's seed, unused
-        respawn_rng = XOROSHIRO(respawn_rng.next())
-        fixed_rng = XOROSHIRO(generator_seed)
-        encounter_slot = (fixed_rng.next() / (2**64)) * encsum
-        fixed_seed = fixed_rng.next()
-        ec,pid,ivs,ability,gender,nature,shiny,square = generate_from_seed(fixed_seed,rolls)
-        if shiny and encounter_slot > 122:
-            print(f"{generator_seed:X} Advance {advance} Respawn {respawn} EC: {ec:08X} PID: {pid:08X} {'/'.join(str(iv) for iv in ivs)}")
-            return True
-    return False
-
 def multi(group_seed,rolls,group_id,maxalive,maxdepth=5):
     path = []
     info = {}
@@ -89,6 +73,7 @@ def generate_spawns(group_seed,rolls,group_id,info,path,adv):
             "square":square,
             "species":species,
             "alpha":alpha,
+            "rolls": rolls,
             "path":(path[:len(path)-1] + [i+1]),
             "adv":adv
         }
@@ -124,6 +109,7 @@ def generate_initial_spawns(group_seed,rolls,group_id,maxalive,info):
             "square":square,
             "species":species,
             "alpha":alpha,
+            "rolls": rolls,
             "path":f"Initial {i}",
             "adv":0
         }

--- a/pla/checkseed.py
+++ b/pla/checkseed.py
@@ -36,7 +36,6 @@ def generate_mass_outbreak_aggressive_path(group_seed,rolls,paths,spawns,true_sp
                 info = {
                     "index":f"<span class='pla-results-init'>Initial Spawn " \
                     f"{init_spawn} </span></span>",
-                    "spawn":True,
                     "generator_seed":f"{generator_seed:X}",
                     "species":species,
                     "shiny":shiny,
@@ -78,7 +77,6 @@ def generate_mass_outbreak_aggressive_path(group_seed,rolls,paths,spawns,true_sp
                     info = {
                         #"index":f"Path: {'|'.join(str(s) for s in steps[:step_i] + [pokemon])} </span>",
                         "index": get_index_string(steps[:step_i], pokemon),
-                        "spawn":True,
                         "generator_seed":f"{generator_seed:X}",
                         "species":species,
                         "shiny":shiny,

--- a/pla/data/data_utils.py
+++ b/pla/data/data_utils.py
@@ -59,3 +59,9 @@ def flatten_bonusround(round, filter, filter_function):
         return [p for b in round.values() for p in b.values() if filter_function(p)]
     else:
         return [p for b in round.values() for p in b.values()]
+
+def flatten_multi(results, filter=True, filter_function=is_shiny):
+    if filter:
+        return [p for p in results.values() if filter_function(p)]
+    else:
+        return list(results.values())

--- a/static/js/distortions.js
+++ b/static/js/distortions.js
@@ -12,7 +12,7 @@ import {
   saveBoolToStorage,
   readBoolFromStorage,
   setupExpandables,
-  showPokemonInformation,
+  showPokemonIVs,
 } from "./modules/common.mjs";
 
 const resultTemplate = document.querySelector("[data-pla-results-template]");
@@ -154,7 +154,7 @@ function getOptions() {
 }
 
 function setMap() {
-  fetch("/map-info", {
+  fetch("/api/map-info", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ map_name: mapSelect.value }),
@@ -185,7 +185,7 @@ function checkDistortions() {
   const options = getOptions();
   showFetchingResults();
 
-  fetch("/read-distortions", {
+  fetch("/api/read-distortions", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(options),
@@ -203,14 +203,10 @@ function showFetchingResults() {
   resultsSection.classList.toggle("pla-loading", true);
 }
 
-const showResults = ({ distortion_spawns }) => {
-  distortion_spawns.forEach((pokemon) => {
-    if (pokemon.spawn) {
-      results.push(pokemon);
-    }
-  });
+function showResults(res) {
+  results.push(...res.results);
   showFilteredResults();
-};
+}
 
 function showFilteredResults() {
   validateFilters();
@@ -222,10 +218,8 @@ function showFilteredResults() {
   resultsArea.innerHTML = "";
   resultsSection.classList.toggle("pla-loading", false);
 
-  const filteredResults = results.filter(
-    (result) =>
-      result.spawn &&
-      filter(result, shinyOrAlphaFilter, shinyFilter, alphaFilter)
+  const filteredResults = results.filter((result) =>
+    filter(result, shinyOrAlphaFilter, shinyFilter, alphaFilter)
   );
 
   if (filteredResults.length > 0) {
@@ -260,20 +254,8 @@ function showFilteredResults() {
         result.ec.toString(16);
       resultContainer.querySelector("[data-pla-results-pid]").innerText =
         result.pid.toString(16);
-      resultContainer.querySelector("[data-pla-results-ivs-hp]").innerText =
-        result.ivs[0];
-      resultContainer.querySelector("[data-pla-results-ivs-att]").innerText =
-        result.ivs[1];
-      resultContainer.querySelector("[data-pla-results-ivs-def]").innerText =
-        result.ivs[2];
-      resultContainer.querySelector("[data-pla-results-ivs-spa]").innerText =
-        result.ivs[3];
-      resultContainer.querySelector("[data-pla-results-ivs-spd]").innerText =
-        result.ivs[4];
-      resultContainer.querySelector("[data-pla-results-ivs-spe]").innerText =
-        result.ivs[5];
 
-      showPokemonInformation(resultContainer, result);
+      showPokemonIVs(resultContainer, result);
 
       resultsArea.appendChild(resultContainer);
     });
@@ -284,7 +266,7 @@ function showFilteredResults() {
 
 function createDistortion() {
   clearMessages();
-  fetch("/create-distortion", {
+  fetch("/api/create-distortion", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
   })

--- a/static/js/distortions.js
+++ b/static/js/distortions.js
@@ -229,6 +229,8 @@ function showResult(result) {
       result.ec.toString(16);
     resultContainer.querySelector("[data-pla-results-pid]").innerText =
       result.pid.toString(16);
+    resultContainer.querySelector("[data-pla-results-rolls]").textContent =
+      result.rolls;
 
     showPokemonIVs(resultContainer, result);
 

--- a/static/js/distortions.js
+++ b/static/js/distortions.js
@@ -6,6 +6,7 @@ import {
   showModalMessage,
   clearMessages,
   clearModalMessages,
+  doSearch,
   showNoResultsFound,
   saveIntToStorage,
   readIntFromStorage,
@@ -19,9 +20,6 @@ const resultTemplate = document.querySelector("[data-pla-results-template]");
 const resultsArea = document.querySelector("[data-pla-results]");
 const mapLocationsArea = document.querySelector("[data-pla-info-locations]");
 const mapSpawnsArea = document.querySelector("[data-pla-info-spawns]");
-const spinnerTemplate = document.querySelector("[data-pla-spinner]");
-
-const resultsSection = document.querySelector(".pla-section-results");
 
 // options
 const mapSelect = document.getElementById("mapSelect");
@@ -182,30 +180,7 @@ function showMapInfo({ locations, spawns }) {
 }
 
 function checkDistortions() {
-  const options = getOptions();
-  showFetchingResults();
-
-  fetch("/api/read-distortions", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(options),
-  })
-    .then((response) => response.json())
-    .then((res) => showResults(res))
-    .catch((error) => showMessage(MESSAGE_ERROR, error));
-}
-
-function showFetchingResults() {
-  results.length = 0;
-  resultsArea.innerHTML = "";
-  const spinner = spinnerTemplate.content.cloneNode(true);
-  resultsArea.appendChild(spinner);
-  resultsSection.classList.toggle("pla-loading", true);
-}
-
-function showResults(res) {
-  results.push(...res.results);
-  showFilteredResults();
+  doSearch("/api/read-distortions", results, getOptions(), showFilteredResults);
 }
 
 function showFilteredResults() {
@@ -215,52 +190,49 @@ function showFilteredResults() {
   let shinyFilter = distShinyCheckbox.checked;
   let alphaFilter = distAlphaCheckbox.checked;
 
-  resultsArea.innerHTML = "";
-  resultsSection.classList.toggle("pla-loading", false);
-
   const filteredResults = results.filter((result) =>
     filter(result, shinyOrAlphaFilter, shinyFilter, alphaFilter)
   );
 
   if (filteredResults.length > 0) {
-    filteredResults.forEach((result) => {
-      const resultContainer = resultTemplate.content.cloneNode(true);
-      resultContainer.querySelector("[data-pla-results-species]").innerText =
-        result.species;
-      resultContainer.querySelector("[data-pla-results-location]").innerText =
-        result.distortion_name;
-
-      let resultShiny = resultContainer.querySelector(
-        "[data-pla-results-shiny]"
-      );
-      resultShiny.innerText = result.shiny;
-      resultShiny.classList.toggle("pla-result-true", result.shiny);
-      resultShiny.classList.toggle("pla-result-false", !result.shiny);
-
-      let resultAlpha = resultContainer.querySelector(
-        "[data-pla-results-alpha]"
-      );
-      resultAlpha.innerText = result.alpha;
-      resultAlpha.classList.toggle("pla-result-true", result.alpha);
-      resultAlpha.classList.toggle("pla-result-false", !result.alpha);
-
-      resultContainer.querySelector("[data-pla-results-nature]").innerText =
-        result.nature;
-      resultContainer.querySelector("[data-pla-results-gender]").innerText =
-        result.gender;
-      resultContainer.querySelector("[data-pla-results-seed]").innerText =
-        result.generator_seed.toString(16);
-      resultContainer.querySelector("[data-pla-results-ec]").innerText =
-        result.ec.toString(16);
-      resultContainer.querySelector("[data-pla-results-pid]").innerText =
-        result.pid.toString(16);
-
-      showPokemonIVs(resultContainer, result);
-
-      resultsArea.appendChild(resultContainer);
-    });
+    filteredResults.forEach((result) => showResult(result));
   } else {
     showNoResultsFound();
+  }
+}
+
+function showResult(result) {
+  {
+    const resultContainer = resultTemplate.content.cloneNode(true);
+    resultContainer.querySelector("[data-pla-results-species]").innerText =
+      result.species;
+    resultContainer.querySelector("[data-pla-results-location]").innerText =
+      result.distortion_name;
+
+    let resultShiny = resultContainer.querySelector("[data-pla-results-shiny]");
+    resultShiny.innerText = result.shiny;
+    resultShiny.classList.toggle("pla-result-true", result.shiny);
+    resultShiny.classList.toggle("pla-result-false", !result.shiny);
+
+    let resultAlpha = resultContainer.querySelector("[data-pla-results-alpha]");
+    resultAlpha.innerText = result.alpha;
+    resultAlpha.classList.toggle("pla-result-true", result.alpha);
+    resultAlpha.classList.toggle("pla-result-false", !result.alpha);
+
+    resultContainer.querySelector("[data-pla-results-nature]").innerText =
+      result.nature;
+    resultContainer.querySelector("[data-pla-results-gender]").innerText =
+      result.gender;
+    resultContainer.querySelector("[data-pla-results-seed]").innerText =
+      result.generator_seed.toString(16);
+    resultContainer.querySelector("[data-pla-results-ec]").innerText =
+      result.ec.toString(16);
+    resultContainer.querySelector("[data-pla-results-pid]").innerText =
+      result.pid.toString(16);
+
+    showPokemonIVs(resultContainer, result);
+
+    resultsArea.appendChild(resultContainer);
   }
 }
 

--- a/static/js/mmos.js
+++ b/static/js/mmos.js
@@ -219,7 +219,6 @@ function checkOneMap() {
 }
 
 function showFilteredResults() {
-  console.log(results);
   validateFilters();
 
   let shinyOrAlphaFilter = distShinyOrAlphaCheckbox.checked;
@@ -356,6 +355,8 @@ function showResult(result) {
     result.ec.toString(16);
   resultContainer.querySelector("[data-pla-results-pid]").innerText =
     result.pid.toString(16);
+  resultContainer.querySelector("[data-pla-results-rolls]").textContent =
+    result.rolls;
 
   showPokemonIVs(resultContainer, result);
 

--- a/static/js/mmos.js
+++ b/static/js/mmos.js
@@ -12,7 +12,7 @@ import {
   saveBoolToStorage,
   readBoolFromStorage,
   setupExpandables,
-  showPokemonInformation,
+  showPokemonIVs,
 } from "./modules/common.mjs";
 
 const resultTemplate = document.querySelector("[data-pla-results-template]");
@@ -160,7 +160,7 @@ function filter(
 
   if (
     speciesFilter.value.length != 0 &&
-    !result.species.toLowerCase().includes(speciesFilter.value.toLowerCase())
+    !result.species.toLowerCase().includes(speciesFilter.toLowerCase())
   ) {
     return false;
   }
@@ -181,7 +181,7 @@ function getOptions() {
 }
 
 function readMaps() {
-  fetch("/read-maps", {
+  fetch("/api/read-maps", {
     method: "GET",
   })
     .then((response) => response.json())
@@ -216,7 +216,7 @@ function checkMMOs() {
   const options = getOptions();
   showFetchingResults();
 
-  fetch("/read-mmos", {
+  fetch("/api/read-mmos", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(options),
@@ -230,13 +230,13 @@ function checkNormals() {
   const options = getOptions();
   showFetchingResults();
 
-  fetch("/read-normals", {
+  fetch("/api/read-normals", {
     method: "POST",
     headers: { "Content-type": "application/json" },
     body: JSON.stringify(options),
   })
     .then((response) => response.json())
-    .then((res) => showNormalResults(res))
+    .then((res) => showResults(res))
     .catch((error) => showMessage(MESSAGE_ERROR, error));
 }
 
@@ -244,18 +244,18 @@ function checkOneMap() {
   const options = getOptions();
   showFetchingResults();
 
-  fetch("/read-one-map", {
+  fetch("/api/read-one-map", {
     method: "POST",
     headers: { "Content-type": "application/json" },
     body: JSON.stringify(options),
   })
     .then((response) => response.json())
-    .then((res) => showMapResults(res))
+    .then((res) => showResults(res))
     .catch((error) => showMessage(MESSAGE_ERROR, error));
 }
 
 function teleportToSpawn(coords) {
-  fetch("/teleport-to-spawn", {
+  fetch("/api/teleport-to-spawn", {
     method: "POST",
     headers: { "Content-type": "application/json" },
     body: JSON.stringify({
@@ -272,18 +272,8 @@ function showFetchingResults() {
   resultsSection.classList.toggle("pla-loading", true);
 }
 
-const showNormalResults = ({ normal_spawns }) => {
-  results.push(...normal_spawns);
-  showFilteredResults();
-};
-
-const showMapResults = ({ mmo_spawn }) => {
-  results.push(...mmo_spawn);
-  showFilteredResults();
-};
-
-function showResults({ mmo_spawns }) {
-  results.push(...mmo_spawns);
+function showResults(res) {
+  results.push(...res.results);
   showFilteredResults();
 }
 
@@ -293,25 +283,23 @@ function showFilteredResults() {
   let shinyOrAlphaFilter = distShinyOrAlphaCheckbox.checked;
   let shinyFilter = distShinyCheckbox.checked;
   let alphaFilter = distAlphaCheckbox.checked;
-  let speciesFilter = mmoSpeciesText;
+  let speciesFilter = mmoSpeciesText.value;
   let defaultFilter = distDefaultCheckbox.checked;
   let multiFilter = distMultiCheckbox.checked;
 
   resultsArea.innerHTML = "";
   resultsSection.classList.toggle("pla-loading", false);
 
-  const filteredResults = results.filter(
-    (result) =>
-      result.spawn &&
-      filter(
-        result,
-        shinyOrAlphaFilter,
-        shinyFilter,
-        alphaFilter,
-        speciesFilter,
-        defaultFilter,
-        multiFilter
-      )
+  const filteredResults = results.filter((result) =>
+    filter(
+      result,
+      shinyOrAlphaFilter,
+      shinyFilter,
+      alphaFilter,
+      speciesFilter,
+      defaultFilter,
+      multiFilter
+    )
   );
 
   if (filteredResults.length > 0) {
@@ -423,20 +411,8 @@ function showFilteredResults() {
         result.ec.toString(16);
       resultContainer.querySelector("[data-pla-results-pid]").innerText =
         result.pid.toString(16);
-      resultContainer.querySelector("[data-pla-results-ivs-hp]").innerText =
-        result.ivs[0];
-      resultContainer.querySelector("[data-pla-results-ivs-att]").innerText =
-        result.ivs[1];
-      resultContainer.querySelector("[data-pla-results-ivs-def]").innerText =
-        result.ivs[2];
-      resultContainer.querySelector("[data-pla-results-ivs-spa]").innerText =
-        result.ivs[3];
-      resultContainer.querySelector("[data-pla-results-ivs-spd]").innerText =
-        result.ivs[4];
-      resultContainer.querySelector("[data-pla-results-ivs-spe]").innerText =
-        result.ivs[5];
 
-      showPokemonInformation(resultContainer, result);
+      showPokemonIVs(resultContainer, result);
 
       let button = document.createElement("button");
       button.innerText = "Teleport to Spawn";

--- a/static/js/modules/common.mjs
+++ b/static/js/modules/common.mjs
@@ -125,7 +125,20 @@ const natureIVs = {
   Docile: [false, false],
 };
 
-export function showPokemonInformation(resultContainer, result) {
+export function showPokemonIVs(resultContainer, result) {
+  resultContainer.querySelector("[data-pla-results-ivs-hp]").innerText =
+    result.ivs[0];
+  resultContainer.querySelector("[data-pla-results-ivs-att]").innerText =
+    result.ivs[1];
+  resultContainer.querySelector("[data-pla-results-ivs-def]").innerText =
+    result.ivs[2];
+  resultContainer.querySelector("[data-pla-results-ivs-spa]").innerText =
+    result.ivs[3];
+  resultContainer.querySelector("[data-pla-results-ivs-spd]").innerText =
+    result.ivs[4];
+  resultContainer.querySelector("[data-pla-results-ivs-spe]").innerText =
+    result.ivs[5];
+  
   const [plusNature, minusNature] = natureIVs[result.nature];
   if (plusNature)
     resultContainer.querySelector(plusNature).classList.add("pla-iv-plus");

--- a/static/js/modules/common.mjs
+++ b/static/js/modules/common.mjs
@@ -49,6 +49,83 @@ export function clearModalMessages() {
 }
 
 // Results Lifecycle
+// This is the big function - basically a metafunction that takes other functions
+// It abstracts a lot of common functionality for any search that will return an array of results to be shown on the page
+// This way a lot of state for eg. spinners is all managed in a single function
+export function doSearch(apiRoute, results, options, displayFunction) {
+  // const research = loadResearchOrError();
+
+  // if (research.hasOwnProperty("error")) {
+  //   // If there's no research, don't perform the search
+  //   return false;
+  // } else {
+  //   options["research"] = research;
+  // }
+
+  // if that's all valid, set the page state to fetching results
+  results.length = 0;
+  showFetchingResults();
+
+  // and do the fetch
+  fetch(apiRoute, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(options),
+  })
+    .then((response) => response.json())
+    .then((res) => {
+      results.length = 0;
+
+      // shows an error if one has been returned
+      if (res.hasOwnProperty("error")) {
+        showMessage(MESSAGE_ERROR, res.error);
+      } else if (res.hasOwnProperty("results")) {
+        results.push(...res.results);
+      }
+
+      setFetchingComplete();
+      displayFunction();
+    })
+    .catch((error) => showResultsError(error));
+
+  return true;
+}
+
+function showFetchingResults() {
+  clearMessages();
+
+  const spinnerTemplate = document.querySelector("[data-pla-spinner]");
+  const spinner = spinnerTemplate.content.cloneNode(true);
+
+  const resultsSection = document.querySelector(".pla-section-results");
+  if (resultsSection) resultsSection.classList.toggle("pla-loading", true);
+
+  const resultsArea = document.querySelector("[data-pla-results]");
+  if (resultsArea) {
+    resultsArea.innerHTML = "";
+    resultsArea.appendChild(spinner);
+  }
+}
+
+function setFetchingComplete() {
+  const resultsSection = document.querySelector(".pla-section-results");
+  if (resultsSection) resultsSection.classList.toggle("pla-loading", false);
+
+  const resultsAreaSpinner = document.querySelector(
+    "[data-pla-results] .pla-spinner"
+  );
+
+  if (resultsAreaSpinner) {
+    resultsAreaSpinner.remove();
+  }
+}
+
+function showResultsError(error) {
+  setFetchingComplete();
+  showMessage(MESSAGE_ERROR, error ?? "An error has occured");
+  console.log(error);
+}
+
 export function showNoResultsFound() {
   const resultsArea = document.querySelector("[data-pla-results]");
   const message = document.createElement("p");
@@ -126,19 +203,19 @@ const natureIVs = {
 };
 
 export function showPokemonIVs(resultContainer, result) {
-  resultContainer.querySelector("[data-pla-results-ivs-hp]").innerText =
+  resultContainer.querySelector("[data-pla-results-ivs-hp]").textContent =
     result.ivs[0];
-  resultContainer.querySelector("[data-pla-results-ivs-att]").innerText =
+  resultContainer.querySelector("[data-pla-results-ivs-att]").textContent =
     result.ivs[1];
-  resultContainer.querySelector("[data-pla-results-ivs-def]").innerText =
+  resultContainer.querySelector("[data-pla-results-ivs-def]").textContent =
     result.ivs[2];
-  resultContainer.querySelector("[data-pla-results-ivs-spa]").innerText =
+  resultContainer.querySelector("[data-pla-results-ivs-spa]").textContent =
     result.ivs[3];
-  resultContainer.querySelector("[data-pla-results-ivs-spd]").innerText =
+  resultContainer.querySelector("[data-pla-results-ivs-spd]").textContent =
     result.ivs[4];
-  resultContainer.querySelector("[data-pla-results-ivs-spe]").innerText =
+  resultContainer.querySelector("[data-pla-results-ivs-spe]").textContent =
     result.ivs[5];
-  
+
   const [plusNature, minusNature] = natureIVs[result.nature];
   if (plusNature)
     resultContainer.querySelector(plusNature).classList.add("pla-iv-plus");

--- a/static/js/multis.js
+++ b/static/js/multis.js
@@ -12,7 +12,7 @@ import {
   saveBoolToStorage,
   readBoolFromStorage,
   setupExpandables,
-  showPokemonInformation,
+  showPokemonIVs,
 } from "./modules/common.mjs";
 
 const resultTemplate = document.querySelector("[data-pla-results-template]");
@@ -126,7 +126,7 @@ function filter(
   shinyOrAlphaFilter,
   shinyFilter,
   alphaFilter,
-  SpeciesFilter
+  speciesFilter
 ) {
   if (shinyOrAlphaFilter && !(result.shiny || result.alpha)) {
     return false;
@@ -141,8 +141,8 @@ function filter(
   }
 
   if (
-    SpeciesFilter.value.length != 0 &&
-    !result.species.toLowerCase().includes(SpeciesFilter.value.toLowerCase())
+    speciesFilter.length != 0 &&
+    !result.species.toLowerCase().includes(speciesFilter.toLowerCase())
   ) {
     return false;
   }
@@ -156,7 +156,7 @@ function getOptions() {
     rolls: parseInt(rollsInput.value),
     group_id: parseInt(groupID.value),
     maxalive: parseInt(maxAlive.value),
-	isnight: nightCheck.checked
+    isnight: nightCheck.checked,
     //	inmap: inmapCheck.checked
   };
 }
@@ -165,7 +165,7 @@ function checkMulti() {
   const options = getOptions();
   showFetchingResults();
 
-  fetch("/check-multi-spawn", {
+  fetch("/api/check-multi-spawn", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(options),
@@ -183,12 +183,8 @@ function showFetchingResults() {
   resultsSection.classList.toggle("pla-loading", true);
 }
 
-function showResults({ multi_spawns }) {
-  for (const [key, value] of Object.entries(multi_spawns)) {
-    if (value.spawn) {
-      results.push(value);
-    }
-  }
+function showResults(res) {
+  results.push(...res.results);
   showFilteredResults();
 }
 
@@ -198,21 +194,13 @@ function showFilteredResults() {
   let shinyOrAlphaFilter = distShinyOrAlphaCheckbox.checked;
   let shinyFilter = distShinyCheckbox.checked;
   let alphaFilter = distAlphaCheckbox.checked;
-  let SpeciesFilter = mmoSpeciesFilter;
+  let speciesFilter = mmoSpeciesText.value;
 
   resultsArea.innerHTML = "";
   resultsSection.classList.toggle("pla-loading", false);
 
-  const filteredResults = results.filter(
-    (result) =>
-      result.spawn &&
-      filter(
-        result,
-        shinyOrAlphaFilter,
-        shinyFilter,
-        alphaFilter,
-        SpeciesFilter
-      )
+  const filteredResults = results.filter((result) =>
+    filter(result, shinyOrAlphaFilter, shinyFilter, alphaFilter, speciesFilter)
   );
 
   if (filteredResults.length > 0) {
@@ -294,20 +282,8 @@ function showFilteredResults() {
         result.ec;
       resultContainer.querySelector("[data-pla-results-pid]").innerText =
         result.pid;
-      resultContainer.querySelector("[data-pla-results-ivs-hp]").innerText =
-        result.ivs[0];
-      resultContainer.querySelector("[data-pla-results-ivs-att]").innerText =
-        result.ivs[1];
-      resultContainer.querySelector("[data-pla-results-ivs-def]").innerText =
-        result.ivs[2];
-      resultContainer.querySelector("[data-pla-results-ivs-spa]").innerText =
-        result.ivs[3];
-      resultContainer.querySelector("[data-pla-results-ivs-spd]").innerText =
-        result.ivs[4];
-      resultContainer.querySelector("[data-pla-results-ivs-spe]").innerText =
-        result.ivs[5];
 
-      showPokemonInformation(resultContainer, result);
+      showPokemonIVs(resultContainer, result);
 
       resultsArea.appendChild(resultContainer);
     });

--- a/static/js/multis.js
+++ b/static/js/multis.js
@@ -260,6 +260,8 @@ function showResult(result) {
   resultContainer.querySelector("[data-pla-results-ec]").innerText = result.ec;
   resultContainer.querySelector("[data-pla-results-pid]").innerText =
     result.pid;
+  resultContainer.querySelector("[data-pla-results-rolls]").textContent =
+    result.rolls;
 
   showPokemonIVs(resultContainer, result);
 

--- a/static/js/multiseed.js
+++ b/static/js/multiseed.js
@@ -6,6 +6,7 @@ import {
   showModalMessage,
   clearMessages,
   clearModalMessages,
+  doSearch,
   showNoResultsFound,
   saveIntToStorage,
   readIntFromStorage,
@@ -17,9 +18,6 @@ import {
 
 const resultTemplate = document.querySelector("[data-pla-results-template]");
 const resultsArea = document.querySelector("[data-pla-results]");
-const spinnerTemplate = document.querySelector("[data-pla-spinner]");
-
-const resultsSection = document.querySelector(".pla-section-results");
 
 // options
 const inputSeed = document.getElementById("inputseed");
@@ -194,31 +192,7 @@ function getOptions() {
 }
 
 function checkMultiSeed() {
-  const options = getOptions();
-  showFetchingResults();
-
-  fetch("/api/check-multi-seed", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(options),
-  })
-    .then((response) => response.json())
-    .then((res) => showResults(res))
-    .catch((error) => showMessage(MESSAGE_ERROR, error));
-}
-
-function showFetchingResults() {
-  results.length = 0;
-  resultsArea.innerHTML = "";
-  const spinner = spinnerTemplate.content.cloneNode(true);
-  resultsArea.appendChild(spinner);
-  resultsSection.classList.toggle("pla-loading", true);
-}
-
-function showResults(res) {
-  console.log(res);
-  results.push(...res.results);
-  showFilteredResults();
+  doSearch("/api/check-multi-seed", results, getOptions(), showFilteredResults);
 }
 
 function showFilteredResults() {
@@ -229,9 +203,6 @@ function showFilteredResults() {
   let alphaFilter = distAlphaCheckbox.checked;
   let speciesFilter = mmoSpeciesText.value;
 
-  resultsArea.innerHTML = "";
-  resultsSection.classList.toggle("pla-loading", false);
-
   const filteredResults = results.filter((result) =>
     filter(result, shinyOrAlphaFilter, shinyFilter, alphaFilter, speciesFilter)
   );
@@ -239,87 +210,84 @@ function showFilteredResults() {
   if (filteredResults.length > 0) {
     resultsArea.innerHTML =
       "<h3><section class='pla-section-results' flow>D = Despawn. Despawn Multiple Pokemon by either Multibattles (for aggressive) or Scaring (for skittish) pokemon.</section></h3>";
-    filteredResults.forEach((result) => {
-      let sprite = document.createElement("img");
-      sprite.src = "static/img/sprite/" + result.sprite;
-
-      let pathdisplay = "Path To Target: &nbsp;";
-      if (result.path.toString().includes("Initial")) {
-        pathdisplay += "<input type='checkbox'>&nbsp;" + result.path;
-      } else {
-        Array.from(result.path).forEach((step) => {
-          pathdisplay +=
-            "<input type='checkbox'>&nbsp;D" + step + "</input> &emsp;";
-        });
-      }
-
-      const resultContainer = resultTemplate.content.cloneNode(true);
-      resultContainer.querySelector(".pla-results-sprite").appendChild(sprite);
-      resultContainer.querySelector("[data-pla-results-species]").innerText =
-        result.species;
-      resultContainer.querySelector("[data-pla-results-location]").innerHTML =
-        pathdisplay;
-
-      let resultShiny = resultContainer.querySelector(
-        "[data-pla-results-shiny]"
-      );
-      let sparkle = "";
-      let sparklesprite = document.createElement("img");
-      sparklesprite.className = "pla-results-sparklesprite";
-      sparklesprite.src =
-        "data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E";
-      sparklesprite.height = "10";
-      sparklesprite.width = "10";
-      sparklesprite.style.cssText =
-        "pull-left;display:inline-block;margin-left:0px;";
-      if (result.shiny && result.square) {
-        sparkle = "Square Shiny!";
-        sparklesprite.src = "static/img/square.png";
-      } else if (result.shiny) {
-        sparklesprite.src = "static/img/shiny.png";
-        sparkle = "Shiny!";
-      } else {
-        sparkle = "Not Shiny";
-      }
-      resultContainer
-        .querySelector("[data-pla-results-shinysprite]")
-        .appendChild(sparklesprite);
-      resultShiny.innerText = sparkle;
-      resultShiny.classList.toggle("pla-result-true", result.shiny);
-      resultShiny.classList.toggle("pla-result-false", !result.shiny);
-
-      let resultAlpha = resultContainer.querySelector(
-        "[data-pla-results-alpha]"
-      );
-      let bigmon = "";
-      if (result.alpha) {
-        bigmon = "Alpha!";
-      } else {
-        bigmon = "Not Alpha";
-      }
-
-      resultAlpha.innerText = bigmon;
-      resultAlpha.classList.toggle("pla-result-true", result.alpha);
-      resultAlpha.classList.toggle("pla-result-false", !result.alpha);
-
-      resultContainer.querySelector("[data-pla-results-adv]").innerText =
-        result.adv;
-
-      resultContainer.querySelector("[data-pla-results-nature]").innerText =
-        result.nature;
-
-      resultContainer.querySelector("[data-pla-results-gender]").innerHTML =
-        result.gender;
-      resultContainer.querySelector("[data-pla-results-ec]").innerText =
-        result.ec;
-      resultContainer.querySelector("[data-pla-results-pid]").innerText =
-        result.pid;
-
-      showPokemonIVs(resultContainer, result);
-
-      resultsArea.appendChild(resultContainer);
-    });
+    filteredResults.forEach((result) => showResult(result));
   } else {
     showNoResultsFound();
   }
+}
+
+function showResult(result) {
+  let sprite = document.createElement("img");
+  sprite.src = "static/img/sprite/" + result.sprite;
+
+  let pathdisplay = "Path To Target: &nbsp;";
+  if (result.path.toString().includes("Initial")) {
+    pathdisplay += "<input type='checkbox'>&nbsp;" + result.path;
+  } else {
+    Array.from(result.path).forEach((step) => {
+      pathdisplay +=
+        "<input type='checkbox'>&nbsp;D" + step + "</input> &emsp;";
+    });
+  }
+
+  const resultContainer = resultTemplate.content.cloneNode(true);
+  resultContainer.querySelector(".pla-results-sprite").appendChild(sprite);
+  resultContainer.querySelector("[data-pla-results-species]").innerText =
+    result.species;
+  resultContainer.querySelector("[data-pla-results-location]").innerHTML =
+    pathdisplay;
+
+  let resultShiny = resultContainer.querySelector("[data-pla-results-shiny]");
+  let sparkle = "";
+  let sparklesprite = document.createElement("img");
+  sparklesprite.className = "pla-results-sparklesprite";
+  sparklesprite.src =
+    "data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E";
+  sparklesprite.height = "10";
+  sparklesprite.width = "10";
+  sparklesprite.style.cssText =
+    "pull-left;display:inline-block;margin-left:0px;";
+  if (result.shiny && result.square) {
+    sparkle = "Square Shiny!";
+    sparklesprite.src = "static/img/square.png";
+  } else if (result.shiny) {
+    sparklesprite.src = "static/img/shiny.png";
+    sparkle = "Shiny!";
+  } else {
+    sparkle = "Not Shiny";
+  }
+  resultContainer
+    .querySelector("[data-pla-results-shinysprite]")
+    .appendChild(sparklesprite);
+  resultShiny.innerText = sparkle;
+  resultShiny.classList.toggle("pla-result-true", result.shiny);
+  resultShiny.classList.toggle("pla-result-false", !result.shiny);
+
+  let resultAlpha = resultContainer.querySelector("[data-pla-results-alpha]");
+  let bigmon = "";
+  if (result.alpha) {
+    bigmon = "Alpha!";
+  } else {
+    bigmon = "Not Alpha";
+  }
+
+  resultAlpha.innerText = bigmon;
+  resultAlpha.classList.toggle("pla-result-true", result.alpha);
+  resultAlpha.classList.toggle("pla-result-false", !result.alpha);
+
+  resultContainer.querySelector("[data-pla-results-adv]").innerText =
+    result.adv;
+
+  resultContainer.querySelector("[data-pla-results-nature]").innerText =
+    result.nature;
+
+  resultContainer.querySelector("[data-pla-results-gender]").innerHTML =
+    result.gender;
+  resultContainer.querySelector("[data-pla-results-ec]").innerText = result.ec;
+  resultContainer.querySelector("[data-pla-results-pid]").innerText =
+    result.pid;
+
+  showPokemonIVs(resultContainer, result);
+
+  resultsArea.appendChild(resultContainer);
 }

--- a/static/js/multiseed.js
+++ b/static/js/multiseed.js
@@ -286,6 +286,8 @@ function showResult(result) {
   resultContainer.querySelector("[data-pla-results-ec]").innerText = result.ec;
   resultContainer.querySelector("[data-pla-results-pid]").innerText =
     result.pid;
+  resultContainer.querySelector("[data-pla-results-rolls]").textContent =
+    result.rolls;
 
   showPokemonIVs(resultContainer, result);
 

--- a/static/js/multiseed.js
+++ b/static/js/multiseed.js
@@ -12,7 +12,7 @@ import {
   saveBoolToStorage,
   readBoolFromStorage,
   setupExpandables,
-  showPokemonInformation,
+  showPokemonIVs,
 } from "./modules/common.mjs";
 
 const resultTemplate = document.querySelector("[data-pla-results-template]");
@@ -28,7 +28,6 @@ const rollsInput = document.getElementById("rolls");
 const maxAlive = document.getElementById("maxAlive");
 const groupID = document.getElementById("groupID");
 const nightCheck = document.getElementById("nightToggle");
-
 
 // filters
 const distShinyOrAlphaCheckbox = document.getElementById(
@@ -94,7 +93,9 @@ function setupPreferenceSaving() {
 
 function setupTabs() {
   document.querySelectorAll(".tablinks").forEach((element) => {
-    element.addEventListener("click", (event) => openTab(event, element.dataset.plaTabFor));
+    element.addEventListener("click", (event) =>
+      openTab(event, element.dataset.plaTabFor)
+    );
   });
 }
 
@@ -156,7 +157,7 @@ function filter(
   shinyOrAlphaFilter,
   shinyFilter,
   alphaFilter,
-  SpeciesFilter
+  speciesFilter
 ) {
   if (shinyOrAlphaFilter && !(result.shiny || result.alpha)) {
     return false;
@@ -171,8 +172,8 @@ function filter(
   }
 
   if (
-    SpeciesFilter.value.length != 0 &&
-    !result.species.toLowerCase().includes(SpeciesFilter.value.toLowerCase())
+    speciesFilter.length != 0 &&
+    !result.species.toLowerCase().includes(speciesFilter.toLowerCase())
   ) {
     return false;
   }
@@ -187,7 +188,7 @@ function getOptions() {
     rolls: parseInt(rollsInput.value),
     group_id: parseInt(groupID.value),
     maxalive: parseInt(maxAlive.value),
-	isnight: nightCheck.checked
+    isnight: nightCheck.checked,
     //	inmap: inmapCheck.checked
   };
 }
@@ -196,7 +197,7 @@ function checkMultiSeed() {
   const options = getOptions();
   showFetchingResults();
 
-  fetch("/check-multi-seed", {
+  fetch("/api/check-multi-seed", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(options),
@@ -214,12 +215,9 @@ function showFetchingResults() {
   resultsSection.classList.toggle("pla-loading", true);
 }
 
-function showResults({ multi_spawns }) {
-  for (const [key, value] of Object.entries(multi_spawns)) {
-    if (value.spawn) {
-      results.push(value);
-    }
-  }
+function showResults(res) {
+  console.log(res);
+  results.push(...res.results);
   showFilteredResults();
 }
 
@@ -229,21 +227,13 @@ function showFilteredResults() {
   let shinyOrAlphaFilter = distShinyOrAlphaCheckbox.checked;
   let shinyFilter = distShinyCheckbox.checked;
   let alphaFilter = distAlphaCheckbox.checked;
-  let SpeciesFilter = mmoSpeciesFilter;
+  let speciesFilter = mmoSpeciesText.value;
 
   resultsArea.innerHTML = "";
   resultsSection.classList.toggle("pla-loading", false);
 
-  const filteredResults = results.filter(
-    (result) =>
-      result.spawn &&
-      filter(
-        result,
-        shinyOrAlphaFilter,
-        shinyFilter,
-        alphaFilter,
-        SpeciesFilter
-      )
+  const filteredResults = results.filter((result) =>
+    filter(result, shinyOrAlphaFilter, shinyFilter, alphaFilter, speciesFilter)
   );
 
   if (filteredResults.length > 0) {
@@ -254,7 +244,6 @@ function showFilteredResults() {
       sprite.src = "static/img/sprite/" + result.sprite;
 
       let pathdisplay = "Path To Target: &nbsp;";
-      console.log(result.path);
       if (result.path.toString().includes("Initial")) {
         pathdisplay += "<input type='checkbox'>&nbsp;" + result.path;
       } else {
@@ -325,20 +314,8 @@ function showFilteredResults() {
         result.ec;
       resultContainer.querySelector("[data-pla-results-pid]").innerText =
         result.pid;
-      resultContainer.querySelector("[data-pla-results-ivs-hp]").innerText =
-        result.ivs[0];
-      resultContainer.querySelector("[data-pla-results-ivs-att]").innerText =
-        result.ivs[1];
-      resultContainer.querySelector("[data-pla-results-ivs-def]").innerText =
-        result.ivs[2];
-      resultContainer.querySelector("[data-pla-results-ivs-spa]").innerText =
-        result.ivs[3];
-      resultContainer.querySelector("[data-pla-results-ivs-spd]").innerText =
-        result.ivs[4];
-      resultContainer.querySelector("[data-pla-results-ivs-spe]").innerText =
-        result.ivs[5];
 
-      showPokemonInformation(resultContainer, result);
+      showPokemonIVs(resultContainer, result);
 
       resultsArea.appendChild(resultContainer);
     });

--- a/static/js/seeds.js
+++ b/static/js/seeds.js
@@ -12,7 +12,7 @@ import {
   saveBoolToStorage,
   readBoolFromStorage,
   setupExpandables,
-  showPokemonInformation,
+  showPokemonIVs,
 } from "./modules/common.mjs";
 
 const resultTemplate = document.querySelector("[data-pla-results-template]");
@@ -180,7 +180,7 @@ function checkMMOs() {
   const options = getOptions();
   showFetchingResults();
 
-  fetch("/check-mmoseed", {
+  fetch("/api/check-mmoseed", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(options),
@@ -198,8 +198,8 @@ function showFetchingResults() {
   resultsSection.classList.toggle("pla-loading", true);
 }
 
-function showResults({ mmo_spawns }) {
-  results.push(...mmo_spawns);
+function showResults(res) {
+  results.push(...res.results);
   showFilteredResults();
 }
 
@@ -215,17 +215,15 @@ function showFilteredResults() {
   resultsArea.innerHTML = "";
   resultsSection.classList.toggle("pla-loading", false);
 
-  const filteredResults = results.filter(
-    (result) =>
-      result.spawn &&
-      filter(
-        result,
-        shinyOrAlphaFilter,
-        shinyFilter,
-        alphaFilter,
-        defaultFilter,
-        multiFilter
-      )
+  const filteredResults = results.filter((result) =>
+    filter(
+      result,
+      shinyOrAlphaFilter,
+      shinyFilter,
+      alphaFilter,
+      defaultFilter,
+      multiFilter
+    )
   );
 
   if (filteredResults.length > 0) {
@@ -301,20 +299,8 @@ function showFilteredResults() {
         result.nature;
       resultContainer.querySelector("[data-pla-results-gender]").innerHTML =
         result.gender;
-      resultContainer.querySelector("[data-pla-results-ivs-hp]").innerText =
-        result.ivs[0];
-      resultContainer.querySelector("[data-pla-results-ivs-att]").innerText =
-        result.ivs[1];
-      resultContainer.querySelector("[data-pla-results-ivs-def]").innerText =
-        result.ivs[2];
-      resultContainer.querySelector("[data-pla-results-ivs-spa]").innerText =
-        result.ivs[3];
-      resultContainer.querySelector("[data-pla-results-ivs-spd]").innerText =
-        result.ivs[4];
-      resultContainer.querySelector("[data-pla-results-ivs-spe]").innerText =
-        result.ivs[5];
 
-      showPokemonInformation(resultContainer, result);
+      showPokemonIVs(resultContainer, result);
 
       resultsArea.appendChild(resultContainer);
     });

--- a/static/js/seeds.js
+++ b/static/js/seeds.js
@@ -273,6 +273,8 @@ function showResult(result) {
     result.nature;
   resultContainer.querySelector("[data-pla-results-gender]").innerHTML =
     result.gender;
+  resultContainer.querySelector("[data-pla-results-rolls]").textContent =
+    result.rolls;
 
   showPokemonIVs(resultContainer, result);
 

--- a/static/js/spawns.js
+++ b/static/js/spawns.js
@@ -6,6 +6,7 @@ import {
   showModalMessage,
   clearMessages,
   clearModalMessages,
+  doSearch,
   showNoResultsFound,
   saveIntToStorage,
   readIntFromStorage,
@@ -17,9 +18,6 @@ import {
 
 const resultTemplate = document.querySelector("[data-pla-results-template]");
 const resultsArea = document.querySelector("[data-pla-results]");
-const spinnerTemplate = document.querySelector("[data-pla-spinner]");
-
-const resultsSection = document.querySelector(".pla-section-results");
 const mapSpawnsArea = document.querySelector("[data-pla-info-spawner]");
 
 // options
@@ -134,68 +132,44 @@ function getOptions() {
 }
 
 function checkAlphaAdv() {
-  const options = getOptions();
-  showFetchingResults();
-
-  fetch("/api/check-alphaseed", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(options),
-  })
-    .then((response) => response.json())
-    .then((res) => showResults(res))
-    .catch((error) => showMessage(MESSAGE_ERROR, error));
-}
-
-function showFetchingResults() {
-  results.length = 0;
-  resultsArea.innerHTML = "";
-  const spinner = spinnerTemplate.content.cloneNode(true);
-  resultsArea.appendChild(spinner);
-  resultsSection.classList.toggle("pla-loading", true);
-}
-
-function showResults(res) {
-  results.push(...res.results);
-  showFilteredResults();
+  doSearch("/api/check-alphaseed", results, getOptions(), showFilteredResults);
 }
 
 function showFilteredResults() {
-  resultsArea.innerHTML = "";
-  resultsSection.classList.toggle("pla-loading", false);
-
   if (results.length > 0) {
-    results.forEach((result) => {
-      console.log(results);
-
-      const resultContainer = resultTemplate.content.cloneNode(true);
-
-      let sprite = document.createElement("img");
-      sprite.src = "static/img/sprite/" + result.sprite;
-
-      resultContainer.querySelector(".pla-results-sprite").appendChild(sprite);
-      resultContainer.querySelector("[data-pla-results-species]").innerText =
-        result.species;
-
-      let resultGender = "Genderless";
-
-      if (result.gender < parseInt(genderFilter.value)) {
-        resultGender = "Female";
-      } else if (parseInt(genderFilter.value) != -1) {
-        resultGender = "Male";
-      }
-
-      resultContainer.querySelector("[data-pla-results-adv]").innerText =
-        result.adv;
-      resultContainer.querySelector("[data-pla-results-nature]").innerText =
-        result.nature;
-      resultContainer.querySelector("[data-pla-results-gender]").innerText =
-        resultGender;
-
-      showPokemonIVs(resultContainer, result);
-      resultsArea.appendChild(resultContainer);
-    });
+    results.forEach((result) => showResult(result));
   } else {
     showNoResultsFound();
   }
+}
+
+function showResult(result) {
+  console.log(results);
+
+  const resultContainer = resultTemplate.content.cloneNode(true);
+
+  let sprite = document.createElement("img");
+  sprite.src = "static/img/sprite/" + result.sprite;
+
+  resultContainer.querySelector(".pla-results-sprite").appendChild(sprite);
+  resultContainer.querySelector("[data-pla-results-species]").innerText =
+    result.species;
+
+  let resultGender = "Genderless";
+
+  if (result.gender < parseInt(genderFilter.value)) {
+    resultGender = "Female";
+  } else if (parseInt(genderFilter.value) != -1) {
+    resultGender = "Male";
+  }
+
+  resultContainer.querySelector("[data-pla-results-adv]").innerText =
+    result.adv;
+  resultContainer.querySelector("[data-pla-results-nature]").innerText =
+    result.nature;
+  resultContainer.querySelector("[data-pla-results-gender]").innerText =
+    resultGender;
+
+  showPokemonIVs(resultContainer, result);
+  resultsArea.appendChild(resultContainer);
 }

--- a/static/js/spawns.js
+++ b/static/js/spawns.js
@@ -12,7 +12,7 @@ import {
   saveBoolToStorage,
   readBoolFromStorage,
   setupExpandables,
-  showPokemonInformation,
+  showPokemonIVs,
 } from "./modules/common.mjs";
 
 const resultTemplate = document.querySelector("[data-pla-results-template]");
@@ -137,7 +137,7 @@ function checkAlphaAdv() {
   const options = getOptions();
   showFetchingResults();
 
-  fetch("/check-alphaseed", {
+  fetch("/api/check-alphaseed", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(options),
@@ -155,10 +155,8 @@ function showFetchingResults() {
   resultsSection.classList.toggle("pla-loading", true);
 }
 
-function showResults({ alpha_spawns }) {
-  if (alpha_spawns.spawn) {
-    results.push(alpha_spawns);
-  }
+function showResults(res) {
+  results.push(...res.results);
   showFilteredResults();
 }
 
@@ -193,20 +191,8 @@ function showFilteredResults() {
         result.nature;
       resultContainer.querySelector("[data-pla-results-gender]").innerText =
         resultGender;
-      resultContainer.querySelector("[data-pla-results-ivs-hp]").innerText =
-        result.ivs[0];
-      resultContainer.querySelector("[data-pla-results-ivs-att]").innerText =
-        result.ivs[1];
-      resultContainer.querySelector("[data-pla-results-ivs-def]").innerText =
-        result.ivs[2];
-      resultContainer.querySelector("[data-pla-results-ivs-spa]").innerText =
-        result.ivs[3];
-      resultContainer.querySelector("[data-pla-results-ivs-spd]").innerText =
-        result.ivs[4];
-      resultContainer.querySelector("[data-pla-results-ivs-spe]").innerText =
-        result.ivs[5];
 
-      showPokemonInformation(resultContainer, result);
+      showPokemonIVs(resultContainer, result);
       resultsArea.appendChild(resultContainer);
     });
   } else {

--- a/static/js/spawns.js
+++ b/static/js/spawns.js
@@ -144,8 +144,6 @@ function showFilteredResults() {
 }
 
 function showResult(result) {
-  console.log(results);
-
   const resultContainer = resultTemplate.content.cloneNode(true);
 
   let sprite = document.createElement("img");
@@ -169,6 +167,8 @@ function showResult(result) {
     result.nature;
   resultContainer.querySelector("[data-pla-results-gender]").innerText =
     resultGender;
+  resultContainer.querySelector("[data-pla-results-rolls]").textContent =
+    result.rolls;
 
   showPokemonIVs(resultContainer, result);
   resultsArea.appendChild(resultContainer);

--- a/templates/pages/multis.html
+++ b/templates/pages/multis.html
@@ -129,6 +129,7 @@
             <ul class="pla-results-ul">
                 <li><span class="pla-results-label">Nature:</span> <span data-pla-results-nature></span></li>
                 <li><span class="pla-results-label">Gender:</span> <span data-pla-results-gender></span></li>
+                <li><span class="pla-results-label">Rolls:</span> <span data-pla-results-rolls></span></li>
             </ul>
 
             <ul class="pla-results-ul">

--- a/templates/pages/multiseed.html
+++ b/templates/pages/multiseed.html
@@ -229,6 +229,7 @@
             <ul class="pla-results-ul">
                 <li><span class="pla-results-label">Nature:</span> <span data-pla-results-nature></span></li>
                 <li><span class="pla-results-label">Gender:</span> <span data-pla-results-gender></span></li>
+                <li><span class="pla-results-label">Rolls:</span> <span data-pla-results-rolls></span></li>
             </ul>
 
             <ul class="pla-results-ul">


### PR DESCRIPTION
This update is all about the `doSearch` function in common.mjs, which extracts the repetitive steps used in getting a result from the backend and displaying it to a user into one place.

You provide the function with:
* an api route
* the page's results object
* an options object to send to the server
* the function that will be used to display the results (the showFilteredResults function).

Note that the last argument is passed as a function, so without the brackets at the end. The doSearch function will then handle a lot of the "lifecycle" of the request - managing showing the loading spinner, showing an error if it is returned from the server instead of the expected results etc. It also provides a single place to hook future updates like checking that the user has specified research levels that will then apply across any search done using this method.

As an example of the error checking that can now happen, if you send a non-numerical seed to the backend, it will return an error message telling the user to put in a number. This can be expanded on in future if needed - you just get the backend to return a dict with an entry "error" in it, and the front end will display that instead of showing results.

Other changes:
* To make use of this, I changed the return format for all search api methods to resturn { "results": [Array of results] }, rather than eg. { "mmo_spawns": MMo results }. This is the format that we're showing on the client.

* Because that meant breaking the existing api functions, I made copies of all the api functions in main.py under api/new-version. I think you had some bots that were using the API? Any that aren't needed can be deleted, I just wanted to make sure that things don't break straight away... but adding in research may mess with some of it a little.

* I removed the "spawn" entry in all the results as it was basically not used anywhere

* Added rolls display to all output to help debug the transition to using research levels - we might decide to remove them in some places in due course of course.

* in checkmmos.py I removed next_filtered_aggressive_outbreak_pathfind_normal, as I worked through the logic of the function and found it was exactly equalent to calling the underlying aggressive_outbreak_pathfind_normal function once